### PR TITLE
store date as meta

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -69,6 +69,7 @@ function collectPosts(channelData, postTypes, config) {
 				meta: {
 					id: getPostId(postData),
 					slug: getPostSlug(postData),
+					date: undefined, // possibly set later in populateFrontmatter()
 					coverImageId: getPostCoverImageId(postData),
 					coverImage: undefined, // possibly set later in mergeImagesIntoPosts()
 					type: postType,
@@ -186,6 +187,7 @@ function populateFrontmatter(posts) {
 			frontmatter[alias || key] = frontmatterGetter(post);
 		});
 		post.frontmatter = frontmatter;
+		post.meta.date = frontmatterGetters['date'](post);
 	});
 }
 

--- a/src/writer.js
+++ b/src/writer.js
@@ -175,9 +175,9 @@ async function loadImageFilePromise(imageUrl) {
 function getPostPath(post, config) {
 	let dt;
 	if (settings.custom_date_formatting) {
-		dt = luxon.DateTime.fromFormat(post.frontmatter.date, settings.custom_date_formatting);
+		dt = luxon.DateTime.fromFormat(post.meta.date, settings.custom_date_formatting);
 	} else {
-		dt = luxon.DateTime.fromISO(post.frontmatter.date);
+		dt = luxon.DateTime.fromISO(post.meta.date);
 	}
 
 	// start with base output dir


### PR DESCRIPTION
`settings.js` で `date` フロントマターに対して `date:pubDate` のようにエイリアスを設定すると、 `writer.js` で `post.frontmatter.date` を見つけられなくなってファイル名の決定ができなくなるため、 `date` 情報を `meta` で保持・参照するように修正した。